### PR TITLE
Use colloid GTK theme

### DIFF
--- a/modules/home-manager/apps/gtk.nix
+++ b/modules/home-manager/apps/gtk.nix
@@ -13,8 +13,8 @@
       size = 10;
     };
     theme = {
-      name = "Adwaita-${theme.variant}";
-      package = pkgs.gnome-themes-extra;
+      name = "Colloid-${if theme.variant == "dark" then "Dark" else "Light"}";
+      package = pkgs.colloid-gtk-theme;
     };
     gtk3.extraConfig = {
       gtk-application-prefer-dark-theme = theme.variant == "dark";

--- a/modules/home-manager/desktop.nix
+++ b/modules/home-manager/desktop.nix
@@ -6,7 +6,7 @@
     libnotify
     rustdesk
     gcr
-    gnome-themes-extra
+    colloid-gtk-theme
     gnome-keyring
     libsecret
     wev


### PR DESCRIPTION
## Summary
- switch GTK theme to Colloid
- include Colloid GTK theme in desktop packages

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake check` *(fails: program 'git' failed with exit code 128)*

------
https://chatgpt.com/codex/tasks/task_e_68989ddfdfc883208a634bb1c6a3ed82